### PR TITLE
Fix translation placement

### DIFF
--- a/content-script/main.js
+++ b/content-script/main.js
@@ -72,13 +72,14 @@
         if (!settings.authCode) {
           // Show a notification that auth code is required
           showAPIKeyNotification();
-          // Remove existing translations if any
-          document
-            .querySelectorAll(".translation-container")
-            .forEach((el) => el.remove());
-        } else {
-          initializeTranslator();
         }
+
+        // Remove existing translations before re-processing
+        document
+          .querySelectorAll(".translation-container")
+          .forEach((el) => el.remove());
+
+        initializeTranslator();
       } else {
         // If translation is turned off, remove all translations
         document
@@ -103,9 +104,8 @@
       if (settings.translationMode !== "off") {
         if (!settings.authCode) {
           showAPIKeyNotification();
-        } else {
-          initializeTranslator();
         }
+        initializeTranslator();
       }
 
       // Listen for messages from background script

--- a/content-script/ui.js
+++ b/content-script/ui.js
@@ -33,7 +33,11 @@ var UI = (function () {
     const settings = Translation.getSettings();
 
     // Skip if this message body already has our translation container
-    if (messageBody.querySelector(".translation-container")) return;
+    if (
+      messageBody.nextElementSibling &&
+      messageBody.nextElementSibling.classList.contains("translation-container")
+    )
+      return;
 
     // Get the message text
     const messageText = getMessageText(messageBody);
@@ -44,9 +48,14 @@ var UI = (function () {
     translationContainer.className = "translation-container";
     translationContainer.style.marginTop = "8px";
     translationContainer.style.padding = "6px 8px";
-    translationContainer.style.backgroundColor = "#f5f7f9";
-    translationContainer.style.borderRadius = "4px";
     translationContainer.style.fontSize = "13px";
+
+    // Try to mirror the message bubble's style
+    const computed = window.getComputedStyle(messageBody);
+    translationContainer.style.backgroundColor =
+      computed.backgroundColor || "#f5f7f9";
+    translationContainer.style.borderRadius =
+      computed.borderRadius || "4px";
     translationContainer.style.borderLeft = "3px solid #4285f4";
 
     // Add initial loading indicator
@@ -56,8 +65,13 @@ var UI = (function () {
     loadingEl.style.fontStyle = "italic";
     translationContainer.appendChild(loadingEl);
 
-    // Append translation container to message body
-    messageBody.appendChild(translationContainer);
+    // Append translation container after the message body so it appears below
+    if (messageBody.parentNode) {
+      messageBody.parentNode.insertBefore(
+        translationContainer,
+        messageBody.nextSibling
+      );
+    }
 
     // Translate based on mode
     if (settings.translationMode === "auto") {

--- a/content.js
+++ b/content.js
@@ -1,0 +1,82 @@
+// content.js - wrapper script for translation bubble injection
+(function () {
+  // Show notification that authorization code is required
+  function showAPIKeyNotification() {
+    if (document.getElementById('api-key-notification')) return;
+
+    const notification = document.createElement('div');
+    notification.id = 'api-key-notification';
+    notification.style.position = 'fixed';
+    notification.style.top = '10px';
+    notification.style.right = '10px';
+    notification.style.backgroundColor = '#f44336';
+    notification.style.color = 'white';
+    notification.style.padding = '15px';
+    notification.style.borderRadius = '5px';
+    notification.style.boxShadow = '0 2px 10px rgba(0,0,0,0.2)';
+    notification.style.zIndex = '9999';
+    notification.style.maxWidth = '300px';
+    notification.innerHTML = `
+      <div style="font-weight:bold;margin-bottom:5px;">Authorization Required</div>
+      <div style="margin-bottom:10px;">Please set the server authorization code in the extension settings.</div>
+      <div style="font-size:12px;">Click the extension icon to add your code.</div>
+      <button id="dismiss-notification" style="margin-top:10px;padding:5px 10px;background:white;color:#f44336;border:none;border-radius:3px;cursor:pointer;">Dismiss</button>`;
+    document.body.appendChild(notification);
+    document.getElementById('dismiss-notification').addEventListener('click', function () {
+      notification.remove();
+    });
+    setTimeout(() => {
+      if (notification.parentNode) notification.remove();
+    }, 10000);
+  }
+
+  function initializeTranslator() {
+    setTimeout(() => {
+      document.querySelectorAll('.message-body').forEach((messageBody) => {
+        UI.processMessageBody(messageBody);
+      });
+      UI.setupOutgoingTranslation();
+      Observers.setupObservers();
+    }, 1000);
+  }
+
+  function handleMessages(request, sender, sendResponse) {
+    if (request.action === 'updateSettings') {
+      const settings = Translation.getSettings();
+      Object.assign(settings, request.settings);
+      if (settings.translationMode !== 'off') {
+        if (!settings.authCode) {
+          showAPIKeyNotification();
+        }
+        document.querySelectorAll('.translation-container').forEach((el) => el.remove());
+        initializeTranslator();
+      } else {
+        document.querySelectorAll('.translation-container').forEach((el) => el.remove());
+      }
+      sendResponse({ success: true });
+      return true;
+    }
+  }
+
+  async function initialize() {
+    try {
+      await Translation.initSettings();
+      const settings = Translation.getSettings();
+      if (settings.translationMode !== 'off') {
+        if (!settings.authCode) {
+          showAPIKeyNotification();
+        }
+        initializeTranslator();
+      }
+      chrome.runtime.onMessage.addListener(handleMessages);
+    } catch (err) {
+      console.error('Error initializing extension:', err);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialize);
+  } else {
+    initialize();
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,8 @@
         "content-script/translation.js",
         "content-script/ui.js",
         "content-script/observers.js",
-        "content-script/main.js"
+        "content-script/main.js",
+        "content.js"
       ],
       "css": [
         "content.css"


### PR DESCRIPTION
## Summary
- initialize translator even when auth key is missing
- style translation bubble using original message style
- reintroduce thin `content.js` wrapper for injection

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68635d36e540832fa6bdbc55222a7ced