### PR TITLE
Add configurable translation placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - 🔄 **Automatic Language Detection:** Detects the original language and translates it to your preferred language.
 - 🛡️ **Privacy First:** No sensitive data is stored; all translations are processed securely.
 - ⚙️ **Customizable Settings:** Set your preferred language and configure translation behavior.
+- 📐 **Flexible Placement:** Choose whether translations appear below or to the right of each message.
 - 🔗 **Seamless Integration:** Integrates directly with the Wire chat interface for a smooth experience.
 
 ## 🖥️ Installation
@@ -25,6 +26,7 @@
 - **Auto-Translate:** Enable or disable automatic message translation.
 - **Highlight Translations:** Toggle highlighted translations for better visibility.
 - **Server Configuration:** Use the default translation server or specify your own address and port. An authorization code is required for all requests.
+- **Translation Placement:** Display translations below each message or to the right of the original bubble.
 
 ## 🐛 Known Issues
 - Occasional delays for lengthy messages.

--- a/background.js
+++ b/background.js
@@ -64,6 +64,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
         useCustomServer: false,
         customServerAddress: "",
         customServerPort: "",
+        translationPlacement: "bottom",
       },
       (settings) => {
         // Send the current settings to the newly loaded tab

--- a/content-script/main.js
+++ b/content-script/main.js
@@ -77,14 +77,36 @@
         // Remove existing translations before re-processing
         document
           .querySelectorAll(".translation-container")
-          .forEach((el) => el.remove());
+          .forEach((el) => {
+            const wrapper = el.parentElement;
+            el.remove();
+            if (
+              wrapper &&
+              wrapper.classList.contains("translation-wrapper")
+            ) {
+              const msg = wrapper.querySelector(".message-body");
+              if (msg) wrapper.parentNode.insertBefore(msg, wrapper);
+              wrapper.remove();
+            }
+          });
 
         initializeTranslator();
       } else {
         // If translation is turned off, remove all translations
         document
           .querySelectorAll(".translation-container")
-          .forEach((el) => el.remove());
+          .forEach((el) => {
+            const wrapper = el.parentElement;
+            el.remove();
+            if (
+              wrapper &&
+              wrapper.classList.contains("translation-wrapper")
+            ) {
+              const msg = wrapper.querySelector(".message-body");
+              if (msg) wrapper.parentNode.insertBefore(msg, wrapper);
+              wrapper.remove();
+            }
+          });
       }
 
       sendResponse({ success: true });

--- a/content-script/translation.js
+++ b/content-script/translation.js
@@ -21,6 +21,7 @@ var Translation = (function () {
     useCustomServer: false,
     customServerAddress: "",
     customServerPort: "",
+    translationPlacement: "bottom",
   };
 
   // Initialize settings
@@ -34,6 +35,7 @@ var Translation = (function () {
           useCustomServer: false,
           customServerAddress: "",
           customServerPort: "",
+          translationPlacement: "bottom",
         },
         (data) => {
           settings = data;

--- a/content-script/ui.js
+++ b/content-script/ui.js
@@ -32,12 +32,13 @@ var UI = (function () {
   function processMessageBody(messageBody) {
     const settings = Translation.getSettings();
 
-    // Skip if this message body already has our translation container
+    // Skip if this message body already has a translation container
     if (
-      messageBody.nextElementSibling &&
-      messageBody.nextElementSibling.classList.contains("translation-container")
-    )
+      messageBody.parentNode &&
+      messageBody.parentNode.querySelector(':scope > .translation-container')
+    ) {
       return;
+    }
 
     // Get the message text
     const messageText = getMessageText(messageBody);
@@ -46,7 +47,10 @@ var UI = (function () {
     // Create translation container
     const translationContainer = document.createElement("div");
     translationContainer.className = "translation-container";
-    translationContainer.style.marginTop = "8px";
+    translationContainer.style.marginTop = settings.translationPlacement ===
+      "bottom"
+        ? "8px"
+        : "0";
     translationContainer.style.padding = "6px 8px";
     translationContainer.style.fontSize = "13px";
 
@@ -65,12 +69,34 @@ var UI = (function () {
     loadingEl.style.fontStyle = "italic";
     translationContainer.appendChild(loadingEl);
 
-    // Append translation container after the message body so it appears below
-    if (messageBody.parentNode) {
-      messageBody.parentNode.insertBefore(
-        translationContainer,
-        messageBody.nextSibling
-      );
+    // Position translation container based on user setting
+    if (settings.translationPlacement === "right") {
+      let wrapper;
+      if (
+        messageBody.parentNode &&
+        messageBody.parentNode.classList.contains("translation-wrapper")
+      ) {
+        wrapper = messageBody.parentNode;
+      } else {
+        wrapper = document.createElement("div");
+        wrapper.className = "translation-wrapper";
+        wrapper.style.display = "flex";
+        wrapper.style.alignItems = "flex-start";
+        wrapper.style.gap = "8px";
+        if (messageBody.parentNode) {
+          messageBody.parentNode.insertBefore(wrapper, messageBody);
+          wrapper.appendChild(messageBody);
+        }
+      }
+      wrapper.appendChild(translationContainer);
+    } else {
+      // Append translation container after the message body (default)
+      if (messageBody.parentNode) {
+        messageBody.parentNode.insertBefore(
+          translationContainer,
+          messageBody.nextSibling
+        );
+      }
     }
 
     // Translate based on mode

--- a/content.css
+++ b/content.css
@@ -83,6 +83,23 @@
   overflow-wrap: break-word;
 }
 
+.translation-wrapper {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  max-width: 100%;
+}
+
+.translation-wrapper .message-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.translation-wrapper .translation-container {
+  flex-shrink: 0;
+  max-width: 45%;
+}
+
 @keyframes slideIn {
   from {
     opacity: 0;

--- a/content.js
+++ b/content.js
@@ -48,10 +48,26 @@
         if (!settings.authCode) {
           showAPIKeyNotification();
         }
-        document.querySelectorAll('.translation-container').forEach((el) => el.remove());
+        document.querySelectorAll('.translation-container').forEach((el) => {
+          const wrapper = el.parentElement;
+          el.remove();
+          if (wrapper && wrapper.classList.contains('translation-wrapper')) {
+            const msg = wrapper.querySelector('.message-body');
+            if (msg) wrapper.parentNode.insertBefore(msg, wrapper);
+            wrapper.remove();
+          }
+        });
         initializeTranslator();
       } else {
-        document.querySelectorAll('.translation-container').forEach((el) => el.remove());
+        document.querySelectorAll('.translation-container').forEach((el) => {
+          const wrapper = el.parentElement;
+          el.remove();
+          if (wrapper && wrapper.classList.contains('translation-wrapper')) {
+            const msg = wrapper.querySelector('.message-body');
+            if (msg) wrapper.parentNode.insertBefore(msg, wrapper);
+            wrapper.remove();
+          }
+        });
       }
       sendResponse({ success: true });
       return true;

--- a/popup.html
+++ b/popup.html
@@ -155,6 +155,20 @@
             </div>
         </div>
 
+        <div class="option-group">
+            <span class="option-title">Translation Placement:</span>
+            <div class="radio-group">
+                <div class="radio-option">
+                    <input type="radio" id="place-bottom" name="translationPlacement" value="bottom" checked>
+                    <label for="place-bottom">Below message</label>
+                </div>
+                <div class="radio-option">
+                    <input type="radio" id="place-right" name="translationPlacement" value="right">
+                    <label for="place-right">Right of message</label>
+                </div>
+            </div>
+        </div>
+
         <div class="api-key-section">
             <span class="option-title">Server Authorization Code:</span>
             <div class="api-key-container">

--- a/popup.js
+++ b/popup.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
       useCustomServer: false,
       customServerAddress: "",
       customServerPort: "",
+      translationPlacement: "bottom",
     },
     function (data) {
       // Set form values to saved values
@@ -26,6 +27,7 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("serverAddress").value = data.customServerAddress || "";
       document.getElementById("serverPort").value = data.customServerPort || "";
       document.getElementById("customServerFields").style.display = data.useCustomServer ? "block" : "none";
+      document.querySelector(`input[name="translationPlacement"][value="${data.translationPlacement || "bottom"}"]`).checked = true;
     }
   );
 
@@ -76,6 +78,9 @@ document.addEventListener("DOMContentLoaded", function () {
       const useCustomServer = document.getElementById("useCustomServer").checked;
       const serverAddress = document.getElementById("serverAddress").value;
       const serverPort = document.getElementById("serverPort").value;
+      const translationPlacement = document.querySelector(
+        'input[name="translationPlacement"]:checked'
+      ).value;
 
       // Show saving status
       const status = document.getElementById("status");
@@ -92,6 +97,7 @@ document.addEventListener("DOMContentLoaded", function () {
             useCustomServer: useCustomServer,
             customServerAddress: serverAddress,
             customServerPort: serverPort,
+            translationPlacement: translationPlacement,
           },
         },
         function (response) {


### PR DESCRIPTION
## Summary
- let users choose whether translations appear to the right of a message or below it
- store the placement option and restore it in the popup
- style side-by-side translations with a flex wrapper
- clean up wrappers when settings change
- refine layout when showing translations on the side

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686361868b5c832f8dc291e77f8314f6