### PR TITLE
Remove custom server port setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@
 - **Preferred Language:** Choose your target language for translation.
 - **Auto-Translate:** Enable or disable automatic message translation.
 - **Highlight Translations:** Toggle highlighted translations for better visibility.
-- **Server Configuration:** Use the default translation server or specify your own address and port. An authorization code is required for all requests.
+- **Server Configuration:** Use the default translation server or specify your own address. Include the port in the URL if needed. An authorization code is required for all requests.
 - **Translation Placement:** Display translations below each message or to the right of the original bubble.
 
 ### 🌐 Server API
-By default the extension sends translation requests to `https://nosugar.fajarlubis.me` using a POST request. You can run your own server and provide its address and port in the settings. Every request includes an `Authorization` header along with an `X-NoSugar-App` header so the server can identify the client.
+By default the extension sends translation requests to `https://nosugar.fajarlubis.me` using a POST request. You can run your own server and provide its address in the settings (add the port in the URL if required). Every request includes an `Authorization` header along with an `X-NoSugar-App` header so the server can identify the client.
 
 Example request body:
 

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -63,7 +63,6 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
         authCode: "",
         useCustomServer: false,
         customServerAddress: "",
-        customServerPort: "",
         translationPlacement: "bottom",
       },
       (settings) => {

--- a/chrome-extension/content-script/translation.js
+++ b/chrome-extension/content-script/translation.js
@@ -20,7 +20,6 @@ var Translation = (function () {
     authCode: "",
     useCustomServer: false,
     customServerAddress: "",
-    customServerPort: "",
     translationPlacement: "bottom",
   };
 
@@ -34,7 +33,6 @@ var Translation = (function () {
           authCode: "",
           useCustomServer: false,
           customServerAddress: "",
-          customServerPort: "",
           translationPlacement: "bottom",
         },
         (data) => {
@@ -93,11 +91,10 @@ var Translation = (function () {
   // Build the server URL depending on user settings
   function getServerURL() {
     if (settings.useCustomServer && settings.customServerAddress) {
-      const port = settings.customServerPort ? `:${settings.customServerPort}` : "";
       const prefix = settings.customServerAddress.startsWith("http")
         ? settings.customServerAddress
         : `http://${settings.customServerAddress}`;
-      return `${prefix}${port}`;
+      return prefix;
     }
     return DEFAULT_SERVER_URL;
   }

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -188,7 +188,6 @@
                 <label><input type="checkbox" id="useCustomServer"> Use custom server</label>
                 <div id="customServerFields" style="display:none;margin-top:8px;">
                     <input type="text" id="serverAddress" placeholder="Server address" style="width:100%;margin-bottom:5px;">
-                    <input type="text" id="serverPort" placeholder="Port" style="width:100%;">
                 </div>
             </div>
             <div style="font-size: 12px; color: #d93025; margin-top: 5px;">

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -11,7 +11,6 @@ document.addEventListener("DOMContentLoaded", function () {
       authCode: "",
       useCustomServer: false,
       customServerAddress: "",
-      customServerPort: "",
       translationPlacement: "bottom",
     },
     function (data) {
@@ -25,7 +24,6 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("authCode").value = data.authCode;
       document.getElementById("useCustomServer").checked = data.useCustomServer;
       document.getElementById("serverAddress").value = data.customServerAddress || "";
-      document.getElementById("serverPort").value = data.customServerPort || "";
       document.getElementById("customServerFields").style.display = data.useCustomServer ? "block" : "none";
       document.querySelector(`input[name="translationPlacement"][value="${data.translationPlacement || "bottom"}"]`).checked = true;
     }
@@ -77,7 +75,6 @@ document.addEventListener("DOMContentLoaded", function () {
       const authCode = document.getElementById("authCode").value;
       const useCustomServer = document.getElementById("useCustomServer").checked;
       const serverAddress = document.getElementById("serverAddress").value;
-      const serverPort = document.getElementById("serverPort").value;
       const translationPlacement = document.querySelector(
         'input[name="translationPlacement"]:checked'
       ).value;
@@ -96,7 +93,6 @@ document.addEventListener("DOMContentLoaded", function () {
             authCode: authCode,
             useCustomServer: useCustomServer,
             customServerAddress: serverAddress,
-            customServerPort: serverPort,
             translationPlacement: translationPlacement,
           },
         },


### PR DESCRIPTION
## Summary
- remove custom server port field from settings UI
- drop port option from popup script and translation logic
- update background storage defaults
- clarify README that full address may include port if needed

## Testing
- `gofmt -w main.go && go vet ./... && go build`

------
https://chatgpt.com/codex/tasks/task_e_68637ac1b9c4832fb8ff0db650ad32e2