### PR TITLE
Enhance popup UI with Tailwind

### DIFF
--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -3,226 +3,120 @@
 
 <head>
     <title>No Sugar Translator</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            width: 320px;
-            padding: 15px;
-            margin: 0;
-            background: #f6f7f8;
-            color: #303030;
-        }
-
-        header {
-            display: flex;
-            align-items: center;
-            margin-bottom: 10px;
-        }
-
-        header img {
-            width: 20px;
-            height: 20px;
-            margin-right: 8px;
-        }
-
-        h2 {
-            margin: 0;
-            font-size: 18px;
-        }
-
-        .option-group {
-            margin-bottom: 15px;
-        }
-
-        .option-title {
-            font-weight: bold;
-            margin-bottom: 8px;
-            display: block;
-        }
-
-        .radio-group {
-            display: flex;
-            flex-direction: column;
-            gap: 8px;
-            margin-left: 5px;
-        }
-
-        .radio-option {
-            display: flex;
-            align-items: center;
-        }
-
-        .radio-option input {
-            margin-right: 8px;
-        }
-
-        label {
-            user-select: none;
-        }
-
-        .api-key-section {
-            margin-top: 15px;
-            padding-top: 15px;
-            border-top: 1px solid #eee;
-        }
-
-        .api-key-container {
-            position: relative;
-            margin-bottom: 10px;
-        }
-
-        #authCode {
-            width: 100%;
-            padding: 8px;
-            padding-right: 35px;
-            box-sizing: border-box;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-        }
-
-        .toggle-password {
-            position: absolute;
-            right: 10px;
-            top: 50%;
-            transform: translateY(-50%);
-            cursor: pointer;
-            background: none;
-            border: none;
-            padding: 0;
-            font-size: 16px;
-            color: #555;
-        }
-
-        #saveButton {
-            background-color: #00b0ff;
-            color: #fff;
-            border: none;
-            padding: 10px 16px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-weight: bold;
-            width: 100%;
-        }
-
-        #saveButton:hover {
-            background-color: #0092d4;
-        }
-
-        #status {
-            margin-top: 10px;
-            text-align: center;
-            min-height: 20px;
-            color: #4CAF50;
-            font-weight: bold;
-        }
-
-        #wsStatus {
-            margin-top: 5px;
-            text-align: center;
-            font-weight: bold;
-        }
-
-        .note {
-            margin-top: 15px;
-            font-size: 12px;
-            color: #666;
-            background: #f5f5f5;
-            padding: 8px;
-            border-radius: 4px;
-        }
-    </style>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 
-<body>
-    <header>
-        <img src="icons/32x32.png" alt="Wire Icon">
-        <h2>No Sugar Translator<span style="font-size: 12px; color: #666; margin-left: 8px;">v2</span></h2>
+<body class="font-sans w-80 p-4 bg-gray-100 text-gray-800">
+    <header class="flex items-start mb-4">
+        <img src="icons/32x32.png" alt="Wire Icon" class="w-5 h-5 mr-2">
+        <div>
+            <h2 class="text-lg flex items-center m-0">
+                No Sugar Translator
+                <span class="ml-2 text-sm text-gray-600">v2</span>
+                <span id="wsStatus" class="ml-1 inline-block w-2 h-2 rounded-full bg-red-500"></span>
+            </h2>
+            <p class="text-xs text-gray-600 mt-1">Pure Translation. No Sugar Added.</p>
+        </div>
     </header>
 
     <form id="settingsForm">
-        <div class="option-group">
-            <span class="option-title">Translation Mode:</span>
-            <div class="radio-group">
-                <div class="radio-option">
-                    <input type="radio" id="auto" name="translationMode" value="auto" checked>
-                    <label for="auto">Auto-detect and translate to selected language</label>
-                </div>
-                <div class="radio-option">
-                    <input type="radio" id="manual" name="translationMode" value="manual">
-                    <label for="manual">Manually translate when clicking messages</label>
-                </div>
-                <div class="radio-option">
-                    <input type="radio" id="off" name="translationMode" value="off">
-                    <label for="off">Turn off translation</label>
-                </div>
-            </div>
-        </div>
-
-        <div class="option-group">
-            <span class="option-title">Target Language:</span>
-            <div class="radio-group">
-                <div class="radio-option">
-                    <input type="radio" id="english" name="targetLanguage" value="en" checked>
-                    <label for="english">English</label>
-                </div>
-                <div class="radio-option">
-                    <input type="radio" id="chinese" name="targetLanguage" value="zh">
-                    <label for="chinese">Chinese</label>
-                </div>
-                <div class="radio-option">
-                    <input type="radio" id="indonesian" name="targetLanguage" value="id">
-                    <label for="indonesian">Indonesian</label>
-                </div>
-            </div>
-        </div>
-
-        <div class="option-group">
-            <span class="option-title">Translation Placement:</span>
-            <div class="radio-group">
-                <div class="radio-option">
-                    <input type="radio" id="place-bottom" name="translationPlacement" value="bottom" checked>
-                    <label for="place-bottom">Below message</label>
-                </div>
-                <div class="radio-option">
-                    <input type="radio" id="place-right" name="translationPlacement" value="right">
-                    <label for="place-right">Right of message</label>
-                </div>
-            </div>
-        </div>
-
-        <div class="api-key-section">
-            <span class="option-title">Server Authorization Code:</span>
-            <div class="api-key-container">
-                <input type="password" id="authCode" name="authCode" placeholder="Enter authorization code">
-                <button type="button" class="toggle-password" title="Show/Hide Code">
-                    <svg width="16" height="16" viewBox="0 0 16 16" id="eye-icon">
-                        <path
-                            d="M8 3C4.5 3 1.5 5.7 0 10c1.5 4.3 4.5 7 8 7s6.5-2.7 8-7c-1.5-4.3-4.5-7-8-7zm0 12c-2.7 0-5.1-2.2-6.4-5.8 1.3-3.6 3.7-5.2 6.4-5.2s5.1 1.6 6.4 5.2c-1.3 3.6-3.7 5.8-6.4 5.8zm0-10a4 4 0 100 8 4 4 0 000-8zm0 6.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" />
+        <div class="mb-4">
+            <span class="font-bold mb-2 block">Translation Mode:</span>
+            <div class="flex space-x-2">
+                <input type="radio" id="auto" name="translationMode" value="auto" class="hidden peer" checked>
+                <label for="auto" class="px-2 py-1 border rounded flex items-center space-x-1 cursor-pointer peer-checked:bg-sky-500 peer-checked:text-white">
+                    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M10 5.5v-3l-7 7 7 7v-3h7v-8h-7z"/>
                     </svg>
-                    <svg width="16" height="16" viewBox="0 0 16 16" id="eye-slash-icon" style="display: none;">
-                        <path
-                            d="M14.53 1.47a.75.75 0 00-1.06 0L11.8 3.14C10.69 2.4 9.38 2 8 2 4.5 2 1.5 4.7 0 9c.73 2.1 1.83 3.76 3.18 4.96l-1.71 1.71a.75.75 0 101.06 1.06l12-12a.75.75 0 000-1.06zM8 14c-2.7 0-5.1-2.2-6.4-5.8.54-1.49 1.31-2.68 2.25-3.5L5.17 6C4.44 6.55 4 7.5 4 8.5c0 2.21 1.79 4 4 4 1 0 1.95-.44 2.5-1.17l1.3 1.32c-.82.94-2.01 1.7-3.8 2.35zM4.85 3.44C5.77 2.9 6.83 2.5 8 2.5c2.7 0 5.1 1.6 6.4 5.2-.54 1.49-1.31 2.68-2.25 3.5L4.85 3.44zM11.83 10c.73-.45 1.17-1.4 1.17-2.4 0-2.21-1.79-4-4-4-1 0-1.95.44-2.5 1.17L11.83 10z" />
+                    <span>Auto</span>
+                </label>
+
+                <input type="radio" id="manual" name="translationMode" value="manual" class="hidden peer">
+                <label for="manual" class="px-2 py-1 border rounded flex items-center space-x-1 cursor-pointer peer-checked:bg-sky-500 peer-checked:text-white">
+                    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M2 10h4l1 2h5v-2h2v6h-2v-2h-7l-3-4z"/>
+                    </svg>
+                    <span>Manual</span>
+                </label>
+
+                <input type="radio" id="off" name="translationMode" value="off" class="hidden peer">
+                <label for="off" class="px-2 py-1 border rounded flex items-center space-x-1 cursor-pointer peer-checked:bg-sky-500 peer-checked:text-white">
+                    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M4 4l12 12m0-12L4 16" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                    <span>Off</span>
+                </label>
+            </div>
+        </div>
+
+        <div class="mb-4">
+            <span class="font-bold mb-2 block">Target Language:</span>
+            <div class="flex space-x-2">
+                <input type="radio" id="english" name="targetLanguage" value="en" class="hidden peer" checked>
+                <label for="english" class="px-2 py-1 border rounded cursor-pointer flex items-center space-x-1 peer-checked:bg-sky-500 peer-checked:text-white">
+                    <span class="w-4 h-4">EN</span>
+                </label>
+
+                <input type="radio" id="chinese" name="targetLanguage" value="zh" class="hidden peer">
+                <label for="chinese" class="px-2 py-1 border rounded cursor-pointer flex items-center space-x-1 peer-checked:bg-sky-500 peer-checked:text-white">
+                    <span class="w-4 h-4">中</span>
+                </label>
+
+                <input type="radio" id="indonesian" name="targetLanguage" value="id" class="hidden peer">
+                <label for="indonesian" class="px-2 py-1 border rounded cursor-pointer flex items-center space-x-1 peer-checked:bg-sky-500 peer-checked:text-white">
+                    <span class="w-4 h-4">ID</span>
+                </label>
+            </div>
+        </div>
+
+        <div class="mb-4">
+            <span class="font-bold mb-2 block">Translation Placement:</span>
+            <div class="flex space-x-2">
+                <input type="radio" id="place-bottom" name="translationPlacement" value="bottom" class="hidden peer" checked>
+                <label for="place-bottom" class="px-2 py-1 border rounded cursor-pointer flex items-center space-x-1 peer-checked:bg-sky-500 peer-checked:text-white">
+                    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M10 4v8m0 0l-3-3m3 3l3-3m-7 6h8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+                    </svg>
+                    <span>Bottom</span>
+                </label>
+
+                <input type="radio" id="place-right" name="translationPlacement" value="right" class="hidden peer">
+                <label for="place-right" class="px-2 py-1 border rounded cursor-pointer flex items-center space-x-1 peer-checked:bg-sky-500 peer-checked:text-white">
+                    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M4 10h8m0 0l-3-3m3 3l-3 3m6-7v8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+                    </svg>
+                    <span>Right</span>
+                </label>
+            </div>
+        </div>
+
+        <div class="mt-4 pt-4 border-t border-gray-200">
+            <span class="font-bold mb-2 block">Server Authorization Code:</span>
+            <div class="relative mb-2">
+                <input type="password" id="authCode" name="authCode" placeholder="Enter authorization code" class="w-full px-2 py-1 pr-8 border rounded">
+                <button type="button" id="copyAuthCode" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500" title="Copy">
+                    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M4 4h9v2H6v9H4V4zm5 3h7a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V8a1 1 0 011-1z"/>
                     </svg>
                 </button>
             </div>
-            <div style="margin-top:10px;">
-                <label><input type="checkbox" id="useCustomServer"> Use custom server</label>
-                <div id="customServerFields" style="display:none;margin-top:8px;">
-                    <input type="text" id="serverAddress" placeholder="Server address" style="width:100%;margin-bottom:5px;">
+            <div class="mt-2">
+                <label class="flex items-center space-x-1"><input type="checkbox" id="useCustomServer" class="mr-1"> <span>Use custom server</span></label>
+                <div id="customServerFields" class="mt-2 hidden">
+                    <input type="text" id="serverAddress" placeholder="Server address" class="w-full px-2 py-1 border rounded mb-1">
                 </div>
             </div>
-            <div style="font-size: 12px; color: #d93025; margin-top: 5px;">
+            <div class="text-xs text-red-600 mt-1">
                 * Authorization code is required for the extension to work
             </div>
         </div>
 
-        <button type="submit" id="saveButton">Save Settings</button>
+        <button type="submit" id="saveButton" class="w-full bg-sky-500 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded">Save Settings</button>
     </form>
 
-    <div id="status"></div>
-    <div id="wsStatus"></div>
+    <div id="status" class="mt-2 text-center min-h-[20px] text-green-600 font-bold"></div>
 
-    <div class="note">
+    <div class="note mt-4 text-xs text-gray-600 bg-gray-200 p-2 rounded">
         <p>Translation is performed in the background as you scroll through messages. No need to click anything if auto
             mode is enabled.</p>
         <p>The extension uses a dedicated translation server. Provide an authorization code or run your own server.</p>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -31,11 +31,8 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   );
 
-  // Toggle password visibility
-  const toggleButton = document.querySelector(".toggle-password");
   const authCodeInput = document.getElementById("authCode");
-  const eyeIcon = document.getElementById("eye-icon");
-  const eyeSlashIcon = document.getElementById("eye-slash-icon");
+  const copyButton = document.getElementById("copyAuthCode");
 
   const customCheckbox = document.getElementById("useCustomServer");
   const customFields = document.getElementById("customServerFields");
@@ -44,20 +41,9 @@ document.addEventListener("DOMContentLoaded", function () {
     customFields.style.display = this.checked ? "block" : "none";
   });
 
-  toggleButton.addEventListener("click", function (e) {
-    // Prevent any potential form submission
+  copyButton.addEventListener("click", function (e) {
     e.preventDefault();
-
-    // Toggle input type between "password" and "text"
-    if (authCodeInput.type === "password") {
-      authCodeInput.type = "text";
-      eyeIcon.style.display = "none";
-      eyeSlashIcon.style.display = "block";
-    } else {
-      authCodeInput.type = "password";
-      eyeIcon.style.display = "block";
-      eyeSlashIcon.style.display = "none";
-    }
+    navigator.clipboard.writeText(authCodeInput.value);
   });
 
   // Form submission handler
@@ -184,20 +170,23 @@ function connectWebSocket(settings) {
     ws = new WebSocket(wsUrl);
     const el = document.getElementById("wsStatus");
     ws.onopen = function () {
-      el.textContent = "Server Connected";
-      el.style.color = "#0f9d58";
+      el.textContent = "";
+      el.classList.remove("bg-red-500");
+      el.classList.add("bg-green-500");
     };
     ws.onclose = function () {
-      el.textContent = "Server Disconnected";
-      el.style.color = "#d93025";
+      el.textContent = "";
+      el.classList.remove("bg-green-500");
+      el.classList.add("bg-red-500");
     };
     ws.onerror = function () {
-      el.textContent = "Server Disconnected";
-      el.style.color = "#d93025";
+      el.textContent = "";
+      el.classList.remove("bg-green-500");
+      el.classList.add("bg-red-500");
     };
   } catch (e) {
     const el = document.getElementById("wsStatus");
-    el.textContent = "Server Disconnected";
-    el.style.color = "#d93025";
+    el.classList.remove("bg-green-500");
+    el.classList.add("bg-red-500");
   }
 }


### PR DESCRIPTION
## Summary
- integrate TailwindCSS and restyle popup UI
- show server status as a coloured circle
- add subtitle to header
- convert radio inputs to button-style groups with icons
- replace reveal icon with copy button
- style custom server fields to match auth input
- update websocket status logic for new indicator

## Testing
- `go vet ./...` *(fails: Forbidden – no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68639768914c832fb59fbb812627948e