### PR TITLE
Add CI and deployment configs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - '.github/workflows/docker-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          push: true
+          tags: ghcr.io/fajarlubis/nosugar:latest

--- a/deploy/deployment.yml
+++ b/deploy/deployment.yml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nosugar-secret
+type: Opaque
+stringData:
+  TRANSLATION_ENGINE: deepl
+  DEEPL_AUTH_KEY: "change_me"
+  GOOGLE_API_KEY: "change_me"
+  CLIENT_API_KEY: "change_me"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nosugar-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nosugar-api
+  template:
+    metadata:
+      labels:
+        app: nosugar-api
+    spec:
+      containers:
+      - name: api
+        image: ghcr.io/fajarlubis/nosugar:latest
+        ports:
+        - containerPort: 8080
+        envFrom:
+        - secretRef:
+            name: nosugar-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nosugar-api
+spec:
+  selector:
+    app: nosugar-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o nosugar ./cmd/nosugar
+
+# Final stage
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/nosugar ./
+EXPOSE 8080
+CMD ["./nosugar"]


### PR DESCRIPTION
## Summary
- build Go server into a Docker image
- publish the image to GHCR with GitHub Actions
- provide Kubernetes manifest with secrets for running the API via Rancher

## Testing
- `gofmt -w server/internal/config/config.go`
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863b316e268832f8aab506cf2050067